### PR TITLE
Change to use absolute py3 hashbang

### DIFF
--- a/usr/lib/mate-optimus/mate-optimus-applet
+++ b/usr/lib/mate-optimus/mate-optimus-applet
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import gettext
 import gi


### PR DESCRIPTION
Embarrassingly trivial change to use absolute path to py3 interpreter rather than relying on /usr/bin/env (which may not return an interpreter that has gtk/gdk/etc installed).