### PR TITLE
Budgie Desktop uses gnome-session-quit to logout

### DIFF
--- a/usr/lib/mate-optimus/mate-optimus-applet
+++ b/usr/lib/mate-optimus/mate-optimus-applet
@@ -117,7 +117,7 @@ def session_logout():
     if current_desktop.startswith('mate'):
         subprocess.Popen(["mate-session-save", "--logout-dialog", "--gui"])
     elif current_desktop.startswith('budgie'):
-        subprocess.Popen(["budgie-session", "--logout"])
+        subprocess.Popen(["gnome-session-quit", "--logout"])
     elif current_desktop.startswith('gnome'):
         subprocess.Popen(["gnome-session-quit", "--logout"])
     elif current_desktop.startswith('kde'):


### PR DESCRIPTION
Tested change on 18.04 and 19.10