### PR TITLE
Disables the checking function has_gpu_screen

### DIFF
--- a/usr/bin/mate-optimus-applet
+++ b/usr/bin/mate-optimus-applet
@@ -74,20 +74,6 @@ def nvidia_detected(capability):
         print('  - nvidia-detector: Skipped')
         return True
 
-def has_gpu_screen(capability):
-    if capability == 'on-demand':
-        providers = subprocess.Popen(['xrandr', '--listproviders'], stdout=PIPE, stderr=DEVNULL)
-        for line in providers.stdout.readlines():
-            text = line.rstrip().decode('utf-8')
-            if 'name:NVIDIA-G' in text:
-                print('  - xrandr: NVIDIA GPU screen detected.')
-                return True
-        print('  - xrandr: NVIDIA GPU screen not detected.')
-        return False
-    else:
-        print('  - xrandr: NVIDIA GPU screen check skipped.')
-        return True
-
 def gpu_loaded(gpu):
     # Does prime-switch report that the GPU is available?
     if gpu == 'intel' or gpu == 'amdgpu' or gpu == 'radeon':
@@ -123,8 +109,7 @@ def check_capability(capability):
     if gpu_loaded(capability) and \
        prime_capable() and \
        nvidia_detected(capability) and \
-       prime_select_features(capability) and \
-       has_gpu_screen(capability):
+       prime_select_features(capability):
         print('  - ' + capability + ': is supported')
         return True
     else:


### PR DESCRIPTION
The function did not fulfill its purpose. The tag 'name:NVIDIA-G' only appears in 'xrandr --listproviders', when on-demand has already been enabled. If nvidia or intel are enabled, it does not appear. As a consequence the option is only listed in the drop down menu, when it is active. There was no chance to select it, if this was not the case. Not sure whether there is another option to check, whether on-demand is actually supported by the running X-server. Nevertheless, this implementation did not serve its purpose.