### PR TITLE
Fixes in offload-glx / offload-vulkan

### DIFF
--- a/usr/bin/mate-optimus-applet
+++ b/usr/bin/mate-optimus-applet
@@ -272,36 +272,34 @@ class Indicator:
     def terminate(self, window = None, data = None):
         Gtk.main_quit()
 
-def offload_launch(mode='', command=['']):
+def offload_launch(mode='', command=[]):
     # Make sure mode is sane.
     if mode != 'offload-glx' and mode != 'offload-vulkan':
         mode = 'offload-none'
 
-    # Validate the command we've be passed.
-    if isinstance(command, list):
-        command_str = ' '.join(command)
-    else:
-        command_str = ''
-
-    if not len(command_str):
+    # Validate the command
+    assert isinstance(command, list), "Expected a list as 'command' argument"
+    if len(command) == 0:
         print(mode + ': No command given, doing nothing.')
         return 1
 
     # Copy the environment so we don't pollute it.
     offload_env = os.environ.copy()
 
+    # Modify the environment to enable offload, see
+    # https://download.nvidia.com/XFree86/Linux-x86_64/435.21/README/primerenderoffload.html
     if mode == 'offload-glx':
         offload_env["__NV_PRIME_RENDER_OFFLOAD"] = "1"
         offload_env["__GLX_VENDOR_LIBRARY_NAME"] = "nvidia"
-        print(mode + ': Launching "' + command_str + '" with NVIDIA offload.')
+        print(mode + ': Launching ' + str(command) + ' with NVIDIA offload.')
     elif mode == 'offload-vulkan':
         offload_env["__NV_PRIME_RENDER_OFFLOAD"] = "1"
-        print(mode + ': Launching "' + command_str + '" with NVIDIA offload.')
+        print(mode + ': Launching ' + str(command) + ' with NVIDIA offload.')
     else:
-        print(mode + ': Launching "' + command_str +'" with no offload.')
+        print(mode + ': Launching ' + str(command) + ' with no offload.')
 
-    # Spawn the process in the users default shell using the modified environment
-    offload = subprocess.Popen(command_str, env=offload_env, shell=True, executable=os.getenv('SHELL', '/bin/sh'))
+    # Spawn the process with the modified environment
+    offload = subprocess.Popen(command, env=offload_env)
     offload.wait()
     return offload.returncode
 

--- a/usr/bin/mate-optimus-applet
+++ b/usr/bin/mate-optimus-applet
@@ -298,10 +298,9 @@ def offload_launch(mode='', command=[]):
     else:
         print(mode + ': Launching ' + str(command) + ' with no offload.')
 
-    # Spawn the process with the modified environment
-    offload = subprocess.Popen(command, env=offload_env)
-    offload.wait()
-    return offload.returncode
+    # Exec the process replacing the current one (the call will not return).
+    # Note that the argument list 'command' needs to include 'command[0]'.
+    os.execvpe(command[0], command, offload_env)
 
 if __name__ == "__main__":
     executable = os.path.basename(__file__)

--- a/usr/bin/mate-optimus-applet
+++ b/usr/bin/mate-optimus-applet
@@ -302,10 +302,11 @@ def offload_launch(mode='', command=[]):
         # Exec the process replacing the current one (the call will not return).
         # Note that the argument list 'command' needs to include 'command[0]'.
         os.execvpe(command[0], command, offload_env)
-        return 0
     except FileNotFoundError:
         print("{}: {}: command not found".format(mode, command[0]))
         return 127
+
+    return 0
 
 if __name__ == "__main__":
     executable = os.path.basename(__file__)

--- a/usr/bin/mate-optimus-applet
+++ b/usr/bin/mate-optimus-applet
@@ -298,9 +298,14 @@ def offload_launch(mode='', command=[]):
     else:
         print(mode + ': Launching ' + str(command) + ' with no offload.')
 
-    # Exec the process replacing the current one (the call will not return).
-    # Note that the argument list 'command' needs to include 'command[0]'.
-    os.execvpe(command[0], command, offload_env)
+    try:
+        # Exec the process replacing the current one (the call will not return).
+        # Note that the argument list 'command' needs to include 'command[0]'.
+        os.execvpe(command[0], command, offload_env)
+        return 0
+    except FileNotFoundError:
+        print("{}: {}: command not found".format(mode, command[0]))
+        return 127
 
 if __name__ == "__main__":
     executable = os.path.basename(__file__)


### PR DESCRIPTION
This PR fixes two issues:

1. Fix handling of white space in arguments for `offload-glx` / `offload-vulkan`

before the patch:
```
$ offload-glx bash -c 'echo this should be printed'
offload-glx: launched.
  - nvidia-settings and prime-select detected.
  - prime-supported: Yes
offload-glx: NVIDIA Optimus supported.
Checking: on-demand
  - on-demand loaded: n/a
  - prime-supported: Yes
  - nvidia-detector: nvidia-driver-440
  - prime-select: on-demand detected.
  - xrandr: NVIDIA GPU screen detected.
  - on-demand: is supported
offload-glx: NVIDIA On-Demand is enabled.
offload-glx: Launching "bash -c echo this should be printed" with NVIDIA offload.

```

after the patch:
```
$ offload-glx bash -c 'echo this should be printed'
offload-glx: launched.
  - nvidia-settings and prime-select detected.
  - prime-supported: Yes
offload-glx: NVIDIA Optimus supported.
Checking: on-demand
  - on-demand loaded: n/a
  - prime-supported: Yes
  - nvidia-detector: nvidia-driver-440
  - prime-select: on-demand detected. tt 
  - on-demand: is supported
offload-glx: NVIDIA On-Demand is enabled.
offload-glx: Launching ['bash', '-c', 'echo this should be printed'] with NVIDIA offload.
this should be printed

```

2. Use `exec` instead of `popen` in `offload-glx` / `offload-vulkan`. This ensures that the wrapper is terminated and replaced by the target process, thus preventing any undesired interaction.

MWE:
```
offload-glx bash -c 'trap "echo got ctrl+c but will not quit" SIGINT; while true; do :; done'
```

This program should keep running after hitting CTRL+C, which is ensured by this patch.